### PR TITLE
Add Tenant to URL when using V2

### DIFF
--- a/AuthBot/Helpers/AzureActiveDirectoryHelper.cs
+++ b/AuthBot/Helpers/AzureActiveDirectoryHelper.cs
@@ -32,9 +32,11 @@ namespace AuthBot.Helpers
             if (string.Equals(AuthSettings.Mode, "v2", StringComparison.OrdinalIgnoreCase))
             {
                 InMemoryTokenCacheMSAL tokenCache = new InMemoryTokenCacheMSAL();
-                Microsoft.Identity.Client.ConfidentialClientApplication client = new Microsoft.Identity.Client.ConfidentialClientApplication(AuthSettings.ClientId, redirectUri.ToString(),
+                Microsoft.Identity.Client.ConfidentialClientApplication client = new Microsoft.Identity.Client.ConfidentialClientApplication("https://login.microsoftonline.com/" + AuthSettings.Tenant + "/oauth2/v2.0",
+                    AuthSettings.ClientId, redirectUri.ToString(),
                     new Microsoft.Identity.Client.ClientCredential(AuthSettings.ClientSecret),
                     tokenCache);
+
 
                 //var uri = "https://login.microsoftonline.com/" + AuthSettings.Tenant + "/oauth2/v2.0/authorize?response_type=code" +
                 //    "&client_id=" + AuthSettings.ClientId +


### PR DESCRIPTION
The Tenant property isn't being taking into consideration when generation the authentication URL therefore we are always authentication against "common".
This is to fix issue #12 .