### PR TITLE
magic number copy paste issue for ms teams

### DIFF
--- a/AuthBot/Controllers/OAuthCallbackController.cs
+++ b/AuthBot/Controllers/OAuthCallbackController.cs
@@ -123,7 +123,7 @@ namespace AuthBot.Controllers
                     else
                     {
                         await Conversation.ResumeAsync(resumptionCookie, message);
-                        if (message.ChannelId == "skypeforbusiness")
+                        if (message.ChannelId == "skypeforbusiness" || message.ChannelId == "msteams")
                             resp.Content = new StringContent($"<html><body>Almost done! Please copy this number and paste it back to your chat so your authentication can complete:<br/> {magicNumber} </body></html>", System.Text.Encoding.UTF8, @"text/html");
                         else
                             resp.Content = new StringContent($"<html><body>Almost done! Please copy this number and paste it back to your chat so your authentication can complete:<br/> <h1>{magicNumber}</h1>.</body></html>", System.Text.Encoding.UTF8, @"text/html");


### PR DESCRIPTION
when magic number is copied from browser and pasted in MS Teams channel, channel sends unwanted html tags (e.g. text which reaches bot is "\n\r\n 389079 \r\n\n"). This fix removes adding any decoration around magic key for ms teams channel.